### PR TITLE
initial self.resize() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Store object `thing` in Plasma, reference later with `name`
 
 Get the value of the object with name `name` from Plasma
 
+`Brain.resize(size)`
+
+Resize the underlying `plasma_store` process to have `size` bytes available. Must be at least as large as the current size of all objects in it.
+
 `Brain.info(name)`
 
 Get the metadata associated with the object with name `name`


### PR DESCRIPTION
solves #4 

is not size-safe, i.e. it doesn't check if the new size is larger than the combined size of the objects currently held like in #7 ; if the size is wrong, it will throw a memory error

this limitation will be fixed with #6 and #7 