### PR TITLE
Size function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The underlying PlasmaClient object. Created at instantiation. Requires plasma_st
 
 The path to the PlasmaClient connection folder. Default is `/tmp/plasma` but can be changed by using `brain = Brain(path='/my/new/path')`
 
-`Brain.size`
+`Brain.bytes`
 
-int - number of bytes available in the plasma_store, e.g. `50000000`
+int - number of bytes available in `plasma_store`
 
 `Brain.mb`
 
@@ -111,6 +111,11 @@ Store object `thing` in Plasma, reference later with `name`
 `Brain.recall(name)`
 
 Get the value of the object with name `name` from Plasma
+
+`Brain.size()`
+
+Calls `brain.client.store_capacity()`, returns int - number of bytes available in the plasma_store, e.g. `50000000`
+
 
 `Brain.resize(size)`
 

--- a/brain-plasma/brain_plasma.py
+++ b/brain-plasma/brain_plasma.py
@@ -120,7 +120,7 @@ class Brain:
             brain.client.delete(temp)
             self.bytes = self.size()
         except:
-            # if not, connect it
+            # if not, start the store and connect it
             if size!=None:
                 self.bytes = size
             if path!=None:
@@ -144,7 +144,7 @@ class Brain:
         self.client = plasma.connect(self.path)    
 
     def size(self):
-        '''show the available bytes of the underlying plasma_store; wrapper for PlasmaClient.store_capacity()l'''
+        '''show the available bytes of the underlying plasma_store; wrapper for PlasmaClient.store_capacity()'''
         self.bytes = self.client.store_capacity()
         return self.bytes
 
@@ -160,7 +160,7 @@ class Brain:
         # create new brain with same path as old brain, but new size
           # this also resets self.bytes to input size (see self.start())
         self.start(size=size)
-        self.client = plasma.connect(self.path)
+        self.wake_up()
         # for each name in the temp brain, save that name & value to the resized brain
         for name in self.temp_brain.names():
             self.learn(self.temp_brain.recall(name),name)

--- a/brain-plasma/brain_plasma.py
+++ b/brain-plasma/brain_plasma.py
@@ -18,19 +18,20 @@ class Brain:
         start_process=True # start plasma_store ?
     ):
         self.path = path
-        self.size = size
+        self.bytes = size
         self.mb = '{} MB'.format(round(size/1000000))
         # start plasma_store if necessary
         if start_process:
             # start the plasma_client - if there is one running at that path, shut it down and restart it with the current size
             try:
-                os.system('plasma_store -m {} -s {} & disown'.format(self.size,self.path))
+                os.system('plasma_store -m {} -s {} & disown'.format(self.bytes,self.path))
             except:
                 os.system('pkill plasma_store')
-                os.system('plasma_store -m {} -s {} & disown'.format(self.size,self.path))
+                os.system('plasma_store -m {} -s {} & disown'.format(self.bytes,self.path))
             # if not proc.returncode:
             #     raise BaseException('BrainError: could not start plasma_store; here is the error message:\n{}',format(proc.stderr))
         self.client = plasma.connect(self.path)
+        self.bytes = self.size()
 
     ### core functions
     def learn(self,thing,name,description=False):
@@ -117,13 +118,14 @@ class Brain:
             # test to see if the client is connected to a plasma_store
             temp = brain.client.put(5)
             brain.client.delete(temp)
+            self.bytes = self.size()
         except:
             # if not, connect it
             if size!=None:
-                self.size = size
+                self.bytes = size
             if path!=None:
                 self.path = path
-            os.system('plasma_store -m {} -s {} & disown'.format(self.size,self.path))
+            os.system('plasma_store -m {} -s {} & disown'.format(self.bytes,self.path))
             self.wake_up()
             
     def dead(self,i_am_sure=True):
@@ -141,17 +143,22 @@ class Brain:
         '''reconnect to the client'''
         self.client = plasma.connect(self.path)    
 
+    def size(self):
+        '''show the available bytes of the underlying plasma_store; wrapper for PlasmaClient.store_capacity()l'''
+        self.bytes = self.client.store_capacity()
+        return self.bytes
+
     def resize(self,size):
         # TODO - add a way to deal with desriptions
         # create temp brain with old size by temp path
-        self.temp_brain = Brain(size=self.size,path='/tmp/plasma-temp',start_process=True)
+        self.temp_brain = Brain(size=self.bytes,path='/tmp/plasma-temp',start_process=True)
         # save the value of each name in the temp brain
         for name in self.names():
             self.temp_brain[name] = self.recall(name)
         # delete the old brain's plasma_store
         self.dead(i_am_sure=True)
         # create new brain with same path as old brain, but new size
-          # this also resets self.size to input size (see self.start())
+          # this also resets self.bytes to input size (see self.start())
         self.start(size=size)
         self.client = plasma.connect(self.path)
         # for each name in the temp brain, save that name & value to the resized brain


### PR DESCRIPTION
Change `brain.size` to `brain.bytes` and added `brain.size()` to dynamically update bytes based on the size of the `plasma_store`. This means that all `Brain` objects will have the correct size reference, even if other `Brain` objects have changed the size. 

##  THIS IS A BREAKING CHANGE 

For anything referencing `brain.size` as an attribute. This should be changed to `brain.size()`. It is recommended to NOT use `brain.bytes` anymore because there is a chance that it is not accurate if other "clients" have changed the size of the `plasma_store`